### PR TITLE
Fix Spanish locale tag

### DIFF
--- a/GameData/JNSQ/JNSQ_Configs/ResearchBodiesLocalization.cfg
+++ b/GameData/JNSQ/JNSQ_Configs/ResearchBodiesLocalization.cfg
@@ -19,7 +19,7 @@ Localization
 		#autoLOC_RBodies_discovery_Enon = Sensor spike detected! Recalibrating. The albedo on this moon is concerningly high.
 		#autoLOC_RBodies_discovery_Prax = The main planet can't be rogue! The number of moons is too damn high!
 	}
-	es-us
+	es-es
 	{
 		#autoLOC_RBodies_discovery_Edna = Just when we though Dres was alone in being leagues larger than anything in the asteroid belt.
 		#autoLOC_RBodies_discovery_Dak = Woah. This moon is really small. We didn't expect to find it, honestly, but we're glad it is where it is. Do you think there is more of it?


### PR DESCRIPTION
This file currently has "es-us" as a locale, implying Spanish as spoken in the USA.

"es-es", Spanish as spoken in Spain, is probably what was meant. This pull request makes that change.