### PR TITLE
Suggest JNSQ-RibbonPack instead of FinalFrontier in CKAN

### DIFF
--- a/CKAN/JNSQ.netkan
+++ b/CKAN/JNSQ.netkan
@@ -48,7 +48,7 @@
       "name": "Strategia"
     },
     {
-      "name": "FinalFrontier"
+      "name": "JNSQ-RibbonPack"
     },
     {
       "name": "TextureReplacer"


### PR DESCRIPTION
See KSP-CKAN/NetKAN#7669; this PR replaces FinalFrontier with JNSQ-RibbonPack in the suggestions list in CKAN. This way users will have the ribbons installed when needed.

Fixes #18.