### PR TITLE
Multiple ModuleDataTransmitters, and UPGRADE nodes

### DIFF
--- a/GameData/JNSQ/JNSQ_Configs/AntennaRange.cfg
+++ b/GameData/JNSQ/JNSQ_Configs/AntennaRange.cfg
@@ -1,21 +1,35 @@
 // Stock or NF Exploration
 @PART:HAS[@MODULE[ModuleDataTransmitter*]]:LAST[JNSQ]
 {
-	@MODULE[ModuleDataTransmitter]
+	@MODULE[ModuleDataTransmitter],*
 	{
 		@antennaPower *= 4
 		%JNSQ = True
+		@UPGRADES
+		{
+			@UPGRADE,*
+			{
+				@antennaPower *= 4
+			}
+		}
 	}
-	@MODULE[ModuleDataTransmitterFeedeable]:NEEDS[NearFutureExploration]
+	@MODULE[ModuleDataTransmitterFeedeable],*:NEEDS[NearFutureExploration]
 	{
 		@antennaPower *= 4
 		%JNSQ = True
+		@UPGRADES
+		{
+			@UPGRADE,*
+			{
+				@antennaPower *= 4
+			}
+		}
 	}
 }
 
 @PART:HAS[@MODULE[ModuleDataTransmitter*]]:LAST[JNSQ]
 {
-	@MODULE[ModuleDataTransmitter*]:HAS[~JNSQ[True]]
+	@MODULE[ModuleDataTransmitter*],*:HAS[~JNSQ[True]]
 	{
 		%JNSQ = False
 	}


### PR DESCRIPTION
Handle weird parts (BDB) with multiple ModuleDataTransmitters, and UPGRADE nodes. I think ProbesPlus uses upgrades, and BDB will be.

I don't have the other mods in this file so I'm not sure it they need this handling.