### PR TITLE
Don't provide Scatterer-sunflare in NetKAN metadata

### DIFF
--- a/CKAN/JNSQ.netkan
+++ b/CKAN/JNSQ.netkan
@@ -14,7 +14,6 @@
   },
   "provides": [
     "EnvironmentalVisualEnhancements-Config",
-    "Scatterer-sunflare",
     "Kronometer"
   ],
   "depends": [
@@ -23,6 +22,9 @@
     },
     {
       "name": "Kopernicus"
+    },
+    {
+      "name" "Scatterer-sunflare-default"
     }
   ],
   "suggests": [

--- a/CKAN/JNSQ.netkan
+++ b/CKAN/JNSQ.netkan
@@ -24,7 +24,7 @@
       "name": "Kopernicus"
     },
     {
-      "name" "Scatterer-sunflare-default"
+      "name": "Scatterer-sunflare-default"
     }
   ],
   "suggests": [


### PR DESCRIPTION
## Problem
@Jognt found out that JNSQ only has a ModuleManager _patch_ which extends on / edits the default Scatterer sunflare. This means it relies on the default sunflare to be installed to work.
https://github.com/Galileo88/JNSQ/blob/1822faa101651ebbd10b5f60ee87b82edfe89a71/GameData/JNSQ/JNSQ_Configs/Scatterer/sunflare01.cfg#L2-L3
We already had the same problem with multiple planet packs, see https://github.com/KSP-CKAN/NetKAN/pull/7794, https://github.com/KSP-CKAN/NetKAN/pull/7800, https://github.com/KSP-CKAN/NetKAN/pull/7870 .

## Changes
This PR removes the `provides` for `Scatterer-sunflare` in the NetKAN file.
Instead, it adds a `"depends": [{ "name": "Scatterer-sunflare-default" }]` to force the installation of the default sunflare (and avoid the possibility that users choose a different sunflare which will be incompatible with JNSQ).

This will need to be backported in the CKAN-meta repo.

Closes https://github.com/Galileo88/JNSQ/issues/26

Pinging @HebaruSan to have a look.