### PR TITLE
Depend on Kronometer, filter out bundled copy

### DIFF
--- a/CKAN/JNSQ.netkan
+++ b/CKAN/JNSQ.netkan
@@ -13,8 +13,7 @@
     "repository": "https://github.com/Galileo88/JNSQ"
   },
   "provides": [
-    "EnvironmentalVisualEnhancements-Config",
-    "Kronometer"
+    "EnvironmentalVisualEnhancements-Config"
   ],
   "depends": [
     {
@@ -25,6 +24,9 @@
     },
     {
       "name": "Scatterer-sunflare-default"
+    },
+    {
+      "name": "Kronometer"
     }
   ],
   "suggests": [
@@ -143,7 +145,8 @@
     {
       "find": "GameData/JNSQ",
       "install_to": "GameData",
-      "comment": "This correctly installs JNSQ"
+      "comment": "This correctly installs JNSQ",
+      "filter": [ "Kronometer" ]
     }
   ]
 }


### PR DESCRIPTION
Hi @JadeOfMaar, this mod currently installs a bundled copy of Kronometer that includes a bundled copy of a Kopernicus DLL which supposedly causes crashes on KSP 1.12 according to @linuxgurugamer:

![image](https://user-images.githubusercontent.com/1559108/131028995-ecd431c6-0ae3-4094-bba3-c297393285b3.png)
![image](https://user-images.githubusercontent.com/1559108/131029158-fbcfccbb-1106-4043-b088-60b6e55b667e.png)

![image](https://user-images.githubusercontent.com/1559108/131028715-a084ce73-13ba-473f-a329-9355f2046ede.png)

This PR updates the metanetkan to depend on the real Kronometer module and filter out the bundled copy, as per @OhioBob's recommendations above.