### PR TITLE
CNC sites for JSQN

### DIFF
--- a/GameData/JNSQ/JNSQ_Configs/CommNetConstellation.cfg
+++ b/GameData/JNSQ/JNSQ_Configs/CommNetConstellation.cfg
@@ -1,0 +1,404 @@
+// CommNetConstellation locations for use with JNSQ.
+// These correspond to the various Kerbal Konstructs sites placed in JNSQ
+//
+// author: Grimmas
+//
+
+@CommNetConstellationSettings:NEEDS[CommNetConstellation]:LAST[JNSQ]
+{
+	// delete existing locations
+	!GroundStations,* {}
+	
+	
+	// add new locations
+	GroundStations
+	{
+		GroundStation
+        {
+            ID = Kerbin: KSC
+            Color = 1,0,0,1
+            OptionalName = KSC
+            TechLevel = 1
+            OverrideLatLongAlt = False
+            CustomLatitude = 0
+            CustomLongitude = 0
+            CustomAltitude = 0
+            CustomCelestialBody = 
+            Frequencies
+            {
+                Frequency = 0
+            }
+        }
+        
+		//GroundStation 
+        //{
+        //    ID = Airbase Boneyard // no mast here
+        //    Color = 1,0,0,1
+        //    OptionalName =
+        //    TechLevel = 0
+        //    OverrideLatLongAlt = True
+        //    CustomLatitude = -0.9241
+        //   CustomLongitude = -92.32729
+        //    CustomAltitude = 0
+        //    CustomCelestialBody = Kerbin
+        //    Frequencies
+        //    {
+        //    }
+        //}
+		
+		GroundStation 
+        {
+			// we need to include the original station IDs otherwise they will be added separately
+            ID = Kerbin: Baikerbanur 
+            Color = 1,0,0,1
+            OptionalName = Airbase N32A // transmitter mast here
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = 32.75399
+            CustomLongitude = 30.113844
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+		
+		GroundStation
+        {
+            ID = Kerbin: Crater Rim
+            Color = 1,0,0,1
+            OptionalName = Airbase N46A  // transmitter mast here
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = 46.14397
+            CustomLongitude = -67.059059
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+		
+		GroundStation
+        {
+            ID = Kerbin: Harvester Massif
+            Color = 1,0,0,1
+            OptionalName = Airbase N76A  // transmitter mast here
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = 76.07489
+            CustomLongitude = 102.267357
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+		
+		GroundStation
+        {
+            ID = Kerbin: Mesa South
+            Color = 1,0,0,1
+            OptionalName = Airbase S00A  // transmitter mast here
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = -0.1378
+            CustomLongitude = 161.95665
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+		
+		GroundStation
+        {
+            ID = Kerbin: North Station One
+            Color = 1,0,0,1
+            OptionalName = Airbase S05A  // transmitter mast here
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = -5.274627
+            CustomLongitude = -70.637187
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+		
+		GroundStation
+        {
+            ID = Kerbin: Nye Island
+            Color = 1,0,0,1
+            OptionalName = Airbase S24A  // transmitter mast here
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = -24.65487
+            CustomLongitude = -75.93416
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+		
+		GroundStation
+        {
+            ID = Kerbin: Desert Launch Facility
+            Color = 1,0,0,1
+            OptionalName = Airbase S28A  // transmitter mast here
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = -28.01061
+            CustomLongitude = 134.03003
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+		
+		GroundStation
+        {
+            ID = Kerbin: Larkes
+            Color = 1,0,0,1
+            OptionalName = Airbase S37A  // transmitter mast here
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = -37.74245
+            CustomLongitude = 13.68022
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+		
+		GroundStation
+        {
+            ID = Airbase S72A  // transmitter mast here
+            Color = 1,0,0,1
+            OptionalName =
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = -72.014427
+            CustomLongitude = -76.10253
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+		
+		GroundStation
+        {
+            ID = Leonov // medium dish here
+            Color = 1,0,0,1
+            OptionalName =
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = 34.442331
+            CustomLongitude = 171.492022
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+		
+		GroundStation
+        {
+            ID = Mc. Auliffe // transmitter mast here
+            Color = 1,0,0,1
+            OptionalName =
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = 10.09791
+            CustomLongitude = -67.21922
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+		
+		GroundStation
+        {
+            ID = Yaeger // transmitter mast here
+            Color = 1,0,0,1
+            OptionalName =
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = 6.0004573
+            CustomLongitude = 26.7967980
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+		
+		GroundStation
+        {
+            ID = Darude // transmitter mast here
+            Color = 1,0,0,1
+            OptionalName =
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = -6.50476
+            CustomLongitude = -144.02834
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+		
+		GroundStation
+        {
+            ID = KSC Harbor // transmitter mast here
+            Color = 1,0,0,1
+            OptionalName =
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = 0.0155
+            CustomLongitude = -91.27190
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+		
+		GroundStation
+        {
+            ID = Mc. Murdo // tracking station here
+            Color = 1,0,0,1
+            OptionalName =
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = -71.86862
+            CustomLongitude = -75.57054
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+		
+		GroundStation
+        {
+            ID = Observatory North // tracking station here
+            Color = 1,0,0,1
+            OptionalName =
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = 18.34007
+            CustomLongitude = 107.02508
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+		
+		GroundStation
+        {
+            ID = Observatory South // tracking station here
+            Color = 1,0,0,1
+            OptionalName =
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = -43.13431
+            CustomLongitude = -52.097592
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+		
+		GroundStation
+        {
+            ID = Musgrave // transmitter outpost here
+            Color = 1,0,0,1
+            OptionalName =
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = -6.664972
+            CustomLongitude = -108.26162
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+		
+		GroundStation
+        {
+            ID = von Kerman Tri // transmitter mast here
+            Color = 1,0,0,1
+            OptionalName =
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = 9.7492996
+            CustomLongitude = 103.963299
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+		
+		GroundStation
+        {
+            ID = Tereshkova // tracking station and transmitter mast here
+            Color = 1,0,0,1
+            OptionalName =
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = 9.77243
+            CustomLongitude = 104.04703
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+				
+		GroundStation
+        {
+            ID = Woomerang // full dish complex here
+            Color = 1,0,0,1
+            OptionalName =
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = 45.292461
+            CustomLongitude = 136.112557
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+				
+		GroundStation
+        {
+            ID = Gagarin // tracking station and transmitter mast here
+            Color = 1,0,0,1
+            OptionalName =
+            TechLevel = 0
+            OverrideLatLongAlt = True
+            CustomLatitude = 3.349791
+            CustomLongitude = -153.20237
+            CustomAltitude = 0
+            CustomCelestialBody = Kerbin
+            Frequencies
+            {
+            }
+        }
+	}
+}
+
+


### PR DESCRIPTION
For users of CommNetConstellation, this drops the stock Kerbin DSN locations from CNC's list of ground stations and instead adds the KK ground station locations from JNSQ.

I did not provide custom altitude data, but as far as I could see in my testing this has no noticeable effect as they are conceptually located on the ground. 

Edit: I've also noticed that it's possible to have KK do this automatically, and when KK is configured to open ground stations then CNC will pick up on that list. However the results of that are suboptimal, with some sites not getting picked up and some sites getting picked up multiple times (three YGagarin for instance - probably related to the number of ground station konstructs present at the location) so I believe the manual approach provides a way better experience for CNC players.