### PR TITLE
Fix cfg syntax

### DIFF
--- a/GameData/JNSQ/JNSQ_Configs/KK/DefaultColor.cfg
+++ b/GameData/JNSQ/JNSQ_Configs/KK/DefaultColor.cfg
@@ -20,7 +20,7 @@ KK_ColorPreset2:NEEDS[KerbalKonstructs]
 	TarmacTexture = BUILTIN:/ksc_exterior_terrain_asphalt
 }
 
-!KK_ColorPreset:HAS[~Name[JNSQ*]] :AFTER[KerbalKonstructs] {}
+!KK_ColorPreset:HAS[~Name[JNSQ*]]:AFTER[KerbalKonstructs] {}
 KK_ColorPreset:NEEDS[KerbalKonstructs]
 {
 	Name = JNSQ KSC

--- a/GameData/JNSQ/JNSQ_Configs/Scatterer/sunflare01.cfg
+++ b/GameData/JNSQ/JNSQ_Configs/Scatterer/sunflare01.cfg
@@ -22,9 +22,9 @@
 		!ghost3SettingsList1 {}
 		!ghost3SettingsList2 {}
 		
-		//@Sunflare_Esther/ghost1SettingsList1:NEEDS[!JNSQNoGhosts] {}
-		//@Sunflare_Esther/ghost2SettingsList1:NEEDS[!JNSQNoGhosts] {}
-		//@Sunflare_Esther/ghost2SettingsList2:NEEDS[!JNSQNoGhosts] {}
-		//@Sunflare_Esther/ghost3SettingsList1:NEEDS[!JNSQNoGhosts] {}
+		#@Sunflare_Esther/ghost1SettingsList1:NEEDS[!JNSQNoGhosts] {}
+		#@Sunflare_Esther/ghost2SettingsList1:NEEDS[!JNSQNoGhosts] {}
+		#@Sunflare_Esther/ghost2SettingsList2:NEEDS[!JNSQNoGhosts] {}
+		#@Sunflare_Esther/ghost3SettingsList1:NEEDS[!JNSQNoGhosts] {}
 	}
 }

--- a/GameData/JNSQ/JNSQ_Configs/Scatterer/sunflare01.cfg
+++ b/GameData/JNSQ/JNSQ_Configs/Scatterer/sunflare01.cfg
@@ -22,9 +22,9 @@
 		!ghost3SettingsList1 {}
 		!ghost3SettingsList2 {}
 		
-		#@Sunflare_Esther/ghost1SettingsList1:NEEDS[!JNSQNoGhosts] {}
-		#@Sunflare_Esther/ghost2SettingsList1:NEEDS[!JNSQNoGhosts] {}
-		#@Sunflare_Esther/ghost2SettingsList2:NEEDS[!JNSQNoGhosts] {}
-		#@Sunflare_Esther/ghost3SettingsList1:NEEDS[!JNSQNoGhosts] {}
+		//@Sunflare_Esther/ghost1SettingsList1:NEEDS[!JNSQNoGhosts] {}
+		//@Sunflare_Esther/ghost2SettingsList1:NEEDS[!JNSQNoGhosts] {}
+		//@Sunflare_Esther/ghost2SettingsList2:NEEDS[!JNSQNoGhosts] {}
+		//@Sunflare_Esther/ghost3SettingsList1:NEEDS[!JNSQNoGhosts] {}
 	}
 }


### PR DESCRIPTION
Hi @OhioBob!

I'm using JNSQ to test some cfg parser code for https://github.com/KSP-CKAN/CKAN/pull/3525, and I found a few minor syntax errors; descriptions/explanations below.
This pull request fixes them.

### `DefaultColor.cfg`

- Extra space between `:HAS` and `:AFTER`, not sure of impact

### `sunflare01.cfg`

- ~~Several lines that look like they were attempted to be commented out with `#`, but `#` is a legal name/key character for config nodes, now changed to `//`~~
  REMOVED. Apparently this is legal syntax ("paste operator") with almost no documentation, but the KSP-RO folks explained it to me.
