### PR TITLE
Fix broken ROC entries

### DIFF
--- a/GameData/JNSQ/JNSQ_Configs/BG_Scatter.cfg
+++ b/GameData/JNSQ/JNSQ_Configs/BG_Scatter.cfg
@@ -104,7 +104,6 @@ ROC_DEFINITION
 		Biome = Lowlands
 		Biome = Midlands
 		Biome = Highlands
-		Biome = Poles
 	}
 }
 ROC_DEFINITION
@@ -301,7 +300,7 @@ ROC_DEFINITION
 	CELESTIALBODY
 	{
 		Name = Moho
-		Biome = Depressions
+		Biome = Craters
 		Biome = Lowlands
 		Biome = Midlands
 		Biome = Highlands
@@ -348,7 +347,7 @@ ROC_DEFINITION
 	CELESTIALBODY
 	{
 		Name = Moho
-		Biome = Depressions
+		Biome = Craters
 		Biome = Lowlands
 		Biome = Midlands
 		Biome = Highlands
@@ -695,7 +694,7 @@ ROC_DEFINITION
 		Biome = Lowlands
 		Biome = Midlands
 		Biome = Highlands
-		Biome = IceCaps
+		Biome = Poles
 	}
 }
 ROC_DEFINITION
@@ -739,7 +738,7 @@ ROC_DEFINITION
 		Biome = Lowlands
 		Biome = Midlands
 		Biome = Highlands
-		Biome = IceCaps
+		Biome = Poles
 	}
 }
 ROC_DEFINITION
@@ -1706,7 +1705,6 @@ ROC_DEFINITION
 		Biome = Mountains
 		Biome = Peaks
 		Biome = PolarLowlands
-		Biome = PolarMidlands
 		Biome = PolarHighlands
 		Biome = Shores
 	}
@@ -1767,7 +1765,6 @@ ROC_DEFINITION
 		Biome = Mountains
 		Biome = Peaks
 		Biome = PolarLowlands
-		Biome = PolarMidlands
 		Biome = PolarHighlands
 		Biome = Shores
 		Biome = MethaneLakes
@@ -2174,7 +2171,7 @@ ROC_DEFINITION
 		Biome = Lowlands
 		Biome = Midlands
 		Biome = Highlands
-		Biome = TwinCrater
+		Biome = TwinCraters
 		Biome = Craters
 		Biome = Pockmarks
 	}


### PR DESCRIPTION
Some ROCs were broken due to misspelled or misnamed biomes.  This fixes that.