### PR TITLE
Fix localization issues and add zh-cn localization

### DIFF
--- a/GameData/JNSQ/JNSQ_Bodies/Duna.cfg
+++ b/GameData/JNSQ/JNSQ_Bodies/Duna.cfg
@@ -33,7 +33,7 @@
 				Biome
 				{
 					name = Trenches
-					displayName = Trenches
+					displayName = #LOC_JNSQ_Biome_Trenches // Trenches
 					value = 1
 					color = #4b2109
 				}

--- a/GameData/JNSQ/JNSQ_Bodies/Edna.cfg
+++ b/GameData/JNSQ/JNSQ_Bodies/Edna.cfg
@@ -60,7 +60,7 @@
 				Biome
 				{
 					name = Whites
-					displayName = Whites
+					displayName = #LOC_JNSQ_Biome_Whites // Whites
 					value = 1
 					color = #cccccc
 				}

--- a/GameData/JNSQ/JNSQ_Bodies/Eve.cfg
+++ b/GameData/JNSQ/JNSQ_Bodies/Eve.cfg
@@ -89,77 +89,77 @@
 				Biome
 				{
 					name = PetrolLakes
-					displayName = Petrol Lakes
+					displayName = #LOC_JNSQ_Biome_PetrolLakes // Petrol Lakes
 					value = 1
 					color = #4E4954
 				}
 				Biome
 				{
 					name = PolarLakes
-					displayName = Polar Lakes
+					displayName = #LOC_JNSQ_Biome_PolarLakes // Polar Lakes
 					value = 1
 					color = #a7a4aa
 				}
 				Biome
 				{
 					name = KrakensWell
-					displayName = Kraken's Well
+					displayName = #LOC_JNSQ_Biome_KrakensWell // Kraken's Well
 					value = 1
 					color = #959298
 				}
 				Biome
 				{
 					name = SeaofAkron
-					displayName = Sea of Akron
+					displayName = #LOC_JNSQ_Biome_SeaofAkron // Sea of Akron
 					value = 1
 					color = #838088
 				}
 				Biome
 				{
 					name = SeaofNessus
-					displayName = Sea of Nessus
+					displayName = #LOC_JNSQ_Biome_SeaofNessus // Sea of Nessus
 					value = 1
 					color = #7a777f
 				}
 				Biome
 				{
 					name = SeaofTaniwha
-					displayName = Sea of Taniwha
+					displayName = #LOC_JNSQ_Biome_SeaofTaniwha // Sea of Taniwha
 					value = 1
 					color = #605c65
 				}
 				Biome
 				{
 					name = SeaofGigan
-					displayName = Sea of Gigan
+					displayName = #LOC_JNSQ_Biome_SeaofGigan // Sea of Gigan
 					value = 1
 					color = #6b5473
 				}
 				Biome
 				{
 					name = SeaofRodan
-					displayName = Sea of Rodan
+					displayName = #LOC_JNSQ_Biome_SeaofRodan // Sea of Rodan
 					value = 1
 					color = #5d4f64
 				}
 				Biome
 				{
 					name = SeaofGojira
-					displayName = Sea of Gojira
+					displayName = #LOC_JNSQ_Biome_SeaofGojira // Sea of Gojira
 					value = 1
 					color = #435d7d
 				}
 				Biome
 				{
 					name = SeaofGhidorah
-					displayName = Sea of Ghidorah
+					displayName = #LOC_JNSQ_Biome_SeaofGhidorah // Sea of Ghidorah
 					value = 1
 					color = #465771
 				}
 				Biome
 				{
 					name = SeaofBagorah
-					displayName = Sea of Bagorah
+					displayName = #LOC_JNSQ_Biome_SeaofBagorah // Sea of Bagorah
 					value = 1
 					color = #4a5164
 				}

--- a/GameData/JNSQ/JNSQ_Bodies/Kerbin.cfg
+++ b/GameData/JNSQ/JNSQ_Bodies/Kerbin.cfg
@@ -44,77 +44,77 @@
 				Biome
 				{
 					name = WelcomeBackIsland
-					displayName = Welcome Back Island
+					displayName = #LOC_JNSQ_Biome_WelcomeBackIsland // Welcome Back Island
 					value = 1
 					color = #405C21
 				}
 				Biome
 				{
 					name = GreatLake
-					displayName = Great Lake
+					displayName = #LOC_JNSQ_Biome_GreatLakes // Great Lake
 					value = 1
 					color = #4fa2b3
 				}
 				Biome
 				{
 					name = InlandWater
-					displayName = Inland Water
+					displayName = #LOC_JNSQ_Biome_InlandWater // Inland Water
 					value = 1
 					color = #7fb9c5
 				}
 				Biome
 				{
 					name = KrenwichSea
-					displayName = Krenwich Sea
+					displayName = #LOC_JNSQ_Biome_KrenwichSea // Krenwich Sea
 					value = 1
 					color = #27317d
 				}
 				Biome
 				{
 					name = ArcticSea
-					displayName = Arctic Sea
+					displayName = #LOC_JNSQ_Biome_ArcticSea // Arctic Sea
 					value = 1
 					color = #7e83de
 				}
 				Biome
 				{
 					name = ForemansSea
-					displayName = Foreman's Sea
+					displayName = #LOC_JNSQ_Biome_ForemansSea // Foreman's Sea
 					value = 1
 					color = #3f439e
 				}
 				Biome
 				{
 					name = TriangulusSea
-					displayName = Triangulus Sea
+					displayName = #LOC_JNSQ_Biome_TriangulusSea // Triangulus Sea
 					value = 1
 					color = #26307a
 				}
 				Biome
 				{
 					name = NorthernSea
-					displayName = Northern Sea
+					displayName = #LOC_JNSQ_Biome_NorthernSea // Northern Sea
 					value = 1
 					color = #2a3586
 				}
 				Biome
 				{
 					name = Sub-ArcticSea
-					displayName = Sub-Arctic Sea
+					displayName = #LOC_JNSQ_Biome_Sub-ArcticSea // Sub-Arctic Sea
 					value = 1
 					color = #4a50bd
 				}
 				Biome
 				{
 					name = EasternSea
-					displayName = Eastern Sea
+					displayName = #LOC_JNSQ_Biome_EasternSea // Eastern Sea
 					value = 1
 					color = #303089
 				}
 				Biome
 				{
 					name = WesternSea
-					displayName = Western Sea
+					displayName = #LOC_JNSQ_Biome_WesternSea // Western Sea
 					value = 1
 					color = #353a91
 				}
@@ -149,28 +149,28 @@
 				Biome
 				{
 					name = AridLowlands
-					displayName = Arid Lowlands
+					displayName = #LOC_JNSQ_Biome_AridLowlands // Arid Lowlands
 					value = 1
 					color = #ad7d49
 				}
 				Biome
 				{
 					name = AridMidlands
-					displayName = Arid Midlands
+					displayName = #LOC_JNSQ_Biome_AridMidlands // Arid Midlands
 					value = 1
 					color = #e0b07c
 				}
 				Biome
 				{
 					name = AridHighlands
-					displayName = Arid Highlands
+					displayName = #LOC_JNSQ_Biome_AridHighlands // Arid Highlands
 					value = 1
 					color = #ebe3af
 				}
 				Biome
 				{
 					name = AridMountains
-					displayName = Arid Mountains
+					displayName = #LOC_JNSQ_Biome_AridMountains // Arid Mountains
 					value = 1
 					color = #f5f5e2
 				}

--- a/GameData/JNSQ/JNSQ_Bodies/Laythe.cfg
+++ b/GameData/JNSQ/JNSQ_Bodies/Laythe.cfg
@@ -53,7 +53,7 @@
 				Biome
 				{
 					name = ArcticSea
-					displayName = #LOC_JNSQ_Biome_ArcticSea = // Arctic Sea
+					displayName = #LOC_JNSQ_Biome_ArcticSea // Arctic Sea
 					value = 1
 					color = #7e83de
 				}

--- a/GameData/JNSQ/JNSQ_Bodies/Laythe.cfg
+++ b/GameData/JNSQ/JNSQ_Bodies/Laythe.cfg
@@ -39,21 +39,21 @@
 				Biome
 				{
 					name = InlandWater
-					displayName = Inland Water
+					displayName = #LOC_JNSQ_Biome_InlandWater // Inland Water
 					value = 1
 					color = #7fb9c5
 				}
 				Biome
 				{
 					name = KrenwichSea
-					displayName = Krenwich Sea
+					displayName = #LOC_JNSQ_Biome_KrenwichSea // Krenwich Sea
 					value = 1
 					color = #27317d
 				}
 				Biome
 				{
 					name = ArcticSea
-					displayName = Arctic Sea
+					displayName = #LOC_JNSQ_Biome_ArcticSea = // Arctic Sea
 					value = 1
 					color = #7e83de
 				}
@@ -67,21 +67,21 @@
 				Biome
 				{
 					name = EnclosedFaults
-					displayName = Enclosed Faults
+					displayName = #LOC_JNSQ_Biome_EnclosedFaults // Enclosed Faults
 					value = 1
 					color = #303089
 				}
 				Biome
 				{
 					name = JoolwardSea
-					displayName = Joolward Sea
+					displayName = #LOC_JNSQ_Biome_JoolwardSea // Joolward Sea
 					value = 1
 					color = #3f439e
 				}
 				Biome
 				{
 					name = Polward Sea
-					displayName = Polward Sea
+					displayName = #LOC_JNSQ_Biome_PolwardSea // Polward Sea
 					value = 1
 					color = #353a91
 				}

--- a/GameData/JNSQ/JNSQ_Bodies/Minmus.cfg
+++ b/GameData/JNSQ/JNSQ_Bodies/Minmus.cfg
@@ -33,7 +33,7 @@
 				Biome
 				{
 					name = Basins
-					displayName = Basins
+					displayName = #LOC_JNSQ_Biome_Basins // Basins
 					value = 1
 					color = #3a4234
 				}
@@ -61,28 +61,28 @@
 				Biome
 				{
 					name = BrownBasins
-					displayName = Brown Basins
+					displayName = #LOC_JNSQ_Biome_BrownBasins // Brown Basins
 					value = 1
 					color = #3f341d
 				}
 				Biome
 				{
 					name = BrownLowlands
-					displayName = Brown Lowlands
+					displayName = #LOC_JNSQ_Biome_BrownLowlands // Brown Lowlands
 					value = 1
 					color = #6d5a32
 				}
 				Biome
 				{
 					name = BrownMidlands
-					displayName = Brown Midlands
+					displayName = #LOC_JNSQ_Biome_BrownMidlands // Brown Midlands
 					value = 1
 					color = #98904a
 				}
 				Biome
 				{
 					name = BrownHighlands
-					displayName = Brown Highlands
+					displayName = #LOC_JNSQ_Biome_BrownHighlands // Brown Highlands
 					value = 1
 					color = #ccc8a5
 				}

--- a/GameData/JNSQ/JNSQ_Bodies/Moho.cfg
+++ b/GameData/JNSQ/JNSQ_Bodies/Moho.cfg
@@ -67,7 +67,7 @@
 				Biome
 				{
 					name = PolarIceCraters
-					displayName = Polar Ice Craters
+					displayName = #LOC_JNSQ_Biome_PolarIceCraters // Polar Ice Craters
 					value = 1
 					color = #d4bdb2
 				}

--- a/GameData/JNSQ/JNSQ_Bodies/Mun.cfg
+++ b/GameData/JNSQ/JNSQ_Bodies/Mun.cfg
@@ -68,7 +68,7 @@
 				Biome
 				{
 					name = PolarIceCraters
-					displayName = Polar Ice Craters
+					displayName = #LOC_JNSQ_Biome_PolarIceCraters // Polar Ice Craters
 					value = 1
 					color = #FFF2F2
 				}

--- a/GameData/JNSQ/JNSQ_Localization/PolwardSea_loc_temp_fix.cfg
+++ b/GameData/JNSQ/JNSQ_Localization/PolwardSea_loc_temp_fix.cfg
@@ -10,7 +10,7 @@
         {
             @Biomes
             {
-                @Biome:HAS[#color[#353a91]]
+                @Biome[Polward?Sea]
                 {
                     @displayName = #LOC_JNSQ_Biome_PolwardSea
                 }

--- a/GameData/JNSQ/JNSQ_Localization/PolwardSea_loc_temp_fix.cfg
+++ b/GameData/JNSQ/JNSQ_Localization/PolwardSea_loc_temp_fix.cfg
@@ -1,0 +1,20 @@
+// In /JNSQ_Bodies/Laythe.cfg, the name for the Polward Sea biome is "Polward Sea", 
+// rather than expected "PolwardSea". This prevents the "Polward Sea" translation 
+// from being loaded and I couldn't fix it properly. So here is a temporary fix.
+
+@Kopernicus:NEEDS[JNSQ]:FINAL
+{
+    @Body[Laythe]
+    {
+        @Properties
+        {
+            @Biomes
+            {
+                @Biome:HAS[#color[#353a91]]
+                {
+                    @displayName = #LOC_JNSQ_Biome_PolwardSea
+                }
+            }
+        }
+    }
+}

--- a/GameData/JNSQ/JNSQ_Localization/de-de.cfg
+++ b/GameData/JNSQ/JNSQ_Localization/de-de.cfg
@@ -120,21 +120,21 @@ Localization
 		// - - - Mods - - -
 		
 		// ResearchBodies
-		#LOC_JNSQ_RBodies_discovery_Edna = Gerade als wir dachten, dass Dres allein eine Liga größer als alle anderen im Asteroidengürtel ist.
-		#LOC_JNSQ_RBodies_discovery_Dak = Woah. Dieser Mond ist wirklich klein. Wir haben nicht erwartet, ihn zu finden, ernsthaft, aber wir sind froh, dass er dort ist, wo er ist. Glaubst du, dass es noch mehr davon gibt?
-		#LOC_JNSQ_RBodies_discovery_Lindor = Da ist ein wirklich großer blauer Punkt. Ein wirklich sehr großer blauer Punkt. Er ist fast so groß wie Jool!
-		#LOC_JNSQ_RBodies_discovery_Krel = Wir haben etwas gefunden. Es scheint unglaublich klein zu sein, aber es umkreist eindeutig den Riesen. Ist es ein riesiger Asteroid?
-		#LOC_JNSQ_RBodies_discovery_Aden = Wir haben einen braunen Punkt gefunden. Wir haben eine Menge brauner Punkte gefunden. Dieses System ist offiziell voller Schoko-Chips.
-		#LOC_JNSQ_RBodies_discovery_Huygen = Wir haben einen hellen und großen gelben Mond entdeckt! .... Wieso merken wir das erst jetzt?
-		#LOC_JNSQ_RBodies_discovery_Riga = Na, hallo. Ein sehr bedeutendes Ziel ist in unser Visier geraten. Es ist verschwommen genug, um möglicherweise auch eine Atmosphäre zu haben.
-		#LOC_JNSQ_RBodies_discovery_Talos = Dieser Mond ist ein bisschen fleckig. Gut, dass er groß und leicht zu erkennen ist.
-		#LOC_JNSQ_RBodies_discovery_Hamek = Da ist ein starker roter Pixel. Ist dieser Bildschirm defekt? Oder ist dieser Planet tatsächlich so?
-		#LOC_JNSQ_RBodies_discovery_Celes = Was ist klein, dunkel und kalt? Dieser Mond! Außerdem das Stück Fleisch, das im Kühlschrank im 3. Stock eingefroren wurde.
-		#LOC_JNSQ_RBodies_discovery_Tam = Häh?
-		#LOC_JNSQ_RBodies_discovery_Nara = Was ist das? Ein Planet? Aber er ist so weit hinter Lindor! Ist er abtrünnig? Oder war er schon immer hier?
-		#LOC_JNSQ_RBodies_discovery_Amos = Wow, dieser Mond ist dunkel! Ist er ein Chip aus dem Bereich seiner Herkunft?
-		#LOC_JNSQ_RBodies_discovery_Enon = Sensorspitze entdeckt! Neukalibrierung. Die Albedo auf diesem Mond ist besorgniserregend hoch.
-		#LOC_JNSQ_RBodies_discovery_Prax = Der Hauptplanet kann nicht abtrünnig sein! Die Anzahl der Monde ist zu hoch!
+		#autoLOC_RBodies_discovery_Edna = Gerade als wir dachten, dass Dres allein eine Liga größer als alle anderen im Asteroidengürtel ist.
+		#autoLOC_RBodies_discovery_Dak = Woah. Dieser Mond ist wirklich klein. Wir haben nicht erwartet, ihn zu finden, ernsthaft, aber wir sind froh, dass er dort ist, wo er ist. Glaubst du, dass es noch mehr davon gibt?
+		#autoLOC_RBodies_discovery_Lindor = Da ist ein wirklich großer blauer Punkt. Ein wirklich sehr großer blauer Punkt. Er ist fast so groß wie Jool!
+		#autoLOC_RBodies_discovery_Krel = Wir haben etwas gefunden. Es scheint unglaublich klein zu sein, aber es umkreist eindeutig den Riesen. Ist es ein riesiger Asteroid?
+		#autoLOC_RBodies_discovery_Aden = Wir haben einen braunen Punkt gefunden. Wir haben eine Menge brauner Punkte gefunden. Dieses System ist offiziell voller Schoko-Chips.
+		#autoLOC_RBodies_discovery_Huygen = Wir haben einen hellen und großen gelben Mond entdeckt! .... Wieso merken wir das erst jetzt?
+		#autoLOC_RBodies_discovery_Riga = Na, hallo. Ein sehr bedeutendes Ziel ist in unser Visier geraten. Es ist verschwommen genug, um möglicherweise auch eine Atmosphäre zu haben.
+		#autoLOC_RBodies_discovery_Talos = Dieser Mond ist ein bisschen fleckig. Gut, dass er groß und leicht zu erkennen ist.
+		#autoLOC_RBodies_discovery_Hamek = Da ist ein starker roter Pixel. Ist dieser Bildschirm defekt? Oder ist dieser Planet tatsächlich so?
+		#autoLOC_RBodies_discovery_Celes = Was ist klein, dunkel und kalt? Dieser Mond! Außerdem das Stück Fleisch, das im Kühlschrank im 3. Stock eingefroren wurde.
+		#autoLOC_RBodies_discovery_Tam = Häh?
+		#autoLOC_RBodies_discovery_Nara = Was ist das? Ein Planet? Aber er ist so weit hinter Lindor! Ist er abtrünnig? Oder war er schon immer hier?
+		#autoLOC_RBodies_discovery_Amos = Wow, dieser Mond ist dunkel! Ist er ein Chip aus dem Bereich seiner Herkunft?
+		#autoLOC_RBodies_discovery_Enon = Sensorspitze entdeckt! Neukalibrierung. Die Albedo auf diesem Mond ist besorgniserregend hoch.
+		#autoLOC_RBodies_discovery_Prax = Der Hauptplanet kann nicht abtrünnig sein! Die Anzahl der Monde ist zu hoch!
 		
 		// - - - Loading tips - - -
 		

--- a/GameData/JNSQ/JNSQ_Localization/de-de.cfg
+++ b/GameData/JNSQ/JNSQ_Localization/de-de.cfg
@@ -1,3 +1,9 @@
+// The following 4 definitions are left untranslated. Please help with them:
+// - #LOC_JNSQ_Biome_WelcomeBackIsland
+// - #LOC_JNSQ_Biome_Whites
+// - #LOC_JNSQ_Biome_Basins
+// - #LOC_JNSQ_Biome_PolarIceCraters
+
 Localization
 {
 	de-de
@@ -50,6 +56,9 @@ Localization
 		#LOC_JNSQ_Biome_BrownMidlands = Braunes Binnenland
 		#LOC_JNSQ_Biome_BrownHighlands = Braunes Hochland
 		#LOC_JNSQ_Biome_EnclosedFaults = Eingeschlossene Muster
+		#LOC_JNSQ_Biome_WelcomeBackIsland = Welcome Back Island
+		#LOC_JNSQ_Biome_Whites = Whites
+		#LOC_JNSQ_Biome_Basins = Basins
 
 		// Craters
 		#LOC_JNSQ_Biome_ExoticCraters = Exotische Krater
@@ -57,6 +66,7 @@ Localization
 		#LOC_JNSQ_Biome_VoronoiCraters = Voronoi Krater
 		#LOC_JNSQ_Biome_NotableCraters = Beachtenswerte Krater
 		#LOC_JNSQ_Biome_Pockmarks = Pockennarben
+		#LOC_JNSQ_Biome_PolarIceCraters = Polar Ice Craters
 		
 		// Oceans
 		#LOC_JNSQ_Biome_InlandWater = Binnengewässer

--- a/GameData/JNSQ/JNSQ_Localization/en-us.cfg
+++ b/GameData/JNSQ/JNSQ_Localization/en-us.cfg
@@ -50,12 +50,17 @@ Localization
 		#LOC_JNSQ_Biome_BrownMidlands = Brown Midlands
 		#LOC_JNSQ_Biome_BrownHighlands = Brown Highlands
 		#LOC_JNSQ_Biome_EnclosedFaults = Enclosed Faults
+		#LOC_JNSQ_Biome_WelcomeBackIsland = Welcome Back Island
+		#LOC_JNSQ_Biome_Whites = Whites
+		#LOC_JNSQ_Biome_Basins = Basins
+
 		// Craters
 		#LOC_JNSQ_Biome_ExoticCraters = Exotic Craters
 		#LOC_JNSQ_Biome_RareCraters = Rare Craters
 		#LOC_JNSQ_Biome_VoronoiCraters = Voronoi Craters
 		#LOC_JNSQ_Biome_NotableCraters = Notable Craters
 		#LOC_JNSQ_Biome_Pockmarks = Pockmarks
+		#LOC_JNSQ_Biome_PolarIceCraters = Polar Ice Craters
 		
 		// Oceans
 		#LOC_JNSQ_Biome_InlandWater = Inland Water
@@ -70,8 +75,10 @@ Localization
 		#LOC_JNSQ_Biome_KrenwichSea = Krenwich Sea
 		#LOC_JNSQ_Biome_JoolwardSea = Joolward Sea
 		#LOC_JNSQ_Biome_PolwardSea = Polward Sea
+
 		// Huygen
 		#LOC_JNSQ_Biome_MethaneLakes = Methane Lakes
+		
 		// Eve
 		#LOC_JNSQ_Biome_PolarLakes = Polar Lakes
 		#LOC_JNSQ_Biome_PetrolLakes = Petrol Lakes

--- a/GameData/JNSQ/JNSQ_Localization/en-us.cfg
+++ b/GameData/JNSQ/JNSQ_Localization/en-us.cfg
@@ -114,21 +114,21 @@ Localization
 		// - - - Mods - - -
 		
 		// ResearchBodies
-		#LOC_JNSQ_RBodies_discovery_Edna = Just when we though Dres was alone in being leagues larger than anything in the asteroid belt.
-		#LOC_JNSQ_RBodies_discovery_Dak = Woah. This moon is really small. We didn't expect to find it, honestly, but we're glad it is where it is. Do you think there is more of it?
-		#LOC_JNSQ_RBodies_discovery_Lindor = There's a really large blue dot. A really really large blue dot. It's nearly as big as Jool!
-		#LOC_JNSQ_RBodies_discovery_Krel = We've found something. Seems incredibly small but it's clearly orbiting the giant. Is it a huge asteroid?
-		#LOC_JNSQ_RBodies_discovery_Aden = We found a brown dot. We found a lot of brown dots. This system is officially full of chocolate chips.
-		#LOC_JNSQ_RBodies_discovery_Huygen = We've spotted a bright and sizable yellow moon! .... How are we only now noticing it?
-		#LOC_JNSQ_RBodies_discovery_Riga = Oh hello. A very sizable target has entered our sights. It's fuzzy enough to possibly have an atmosphere too.
-		#LOC_JNSQ_RBodies_discovery_Talos = This moon is a bit splotchy. Good thing it's big and easy to spot.
-		#LOC_JNSQ_RBodies_discovery_Hamek = There's a strong red pixel. Is this screen dying? Or is that actually how this planet is?
-		#LOC_JNSQ_RBodies_discovery_Celes = What's small, dark, and cold? This moon! Also, the chunk of meat that's getting freezer-burn in the fridge on 3rd floor.
-		#LOC_JNSQ_RBodies_discovery_Tam = Bruh. // Oh dear.
-		#LOC_JNSQ_RBodies_discovery_Nara = What's this? A planet? But it's so far past Lindor! Is it rogue? Or has it always been here?
-		#LOC_JNSQ_RBodies_discovery_Amos = Wow this moon is dark! Is it a chip off of its parent's block?
-		#LOC_JNSQ_RBodies_discovery_Enon = Sensor spike detected! Recalibrating. The albedo on this moon is concerningly high.
-		#LOC_JNSQ_RBodies_discovery_Prax = The main planet can't be rogue! The number of moons is too damn high!
+		#autoLOC_RBodies_discovery_Edna = Just when we though Dres was alone in being leagues larger than anything in the asteroid belt.
+		#autoLOC_RBodies_discovery_Dak = Woah. This moon is really small. We didn't expect to find it, honestly, but we're glad it is where it is. Do you think there is more of it?
+		#autoLOC_RBodies_discovery_Lindor = There's a really large blue dot. A really really large blue dot. It's nearly as big as Jool!
+		#autoLOC_RBodies_discovery_Krel = We've found something. Seems incredibly small but it's clearly orbiting the giant. Is it a huge asteroid?
+		#autoLOC_RBodies_discovery_Aden = We found a brown dot. We found a lot of brown dots. This system is officially full of chocolate chips.
+		#autoLOC_RBodies_discovery_Huygen = We've spotted a bright and sizable yellow moon! .... How are we only now noticing it?
+		#autoLOC_RBodies_discovery_Riga = Oh hello. A very sizable target has entered our sights. It's fuzzy enough to possibly have an atmosphere too.
+		#autoLOC_RBodies_discovery_Talos = This moon is a bit splotchy. Good thing it's big and easy to spot.
+		#autoLOC_RBodies_discovery_Hamek = There's a strong red pixel. Is this screen dying? Or is that actually how this planet is?
+		#autoLOC_RBodies_discovery_Celes = What's small, dark, and cold? This moon! Also, the chunk of meat that's getting freezer-burn in the fridge on 3rd floor.
+		#autoLOC_RBodies_discovery_Tam = Bruh. // Oh dear.
+		#autoLOC_RBodies_discovery_Nara = What's this? A planet? But it's so far past Lindor! Is it rogue? Or has it always been here?
+		#autoLOC_RBodies_discovery_Amos = Wow this moon is dark! Is it a chip off of its parent's block?
+		#autoLOC_RBodies_discovery_Enon = Sensor spike detected! Recalibrating. The albedo on this moon is concerningly high.
+		#autoLOC_RBodies_discovery_Prax = The main planet can't be rogue! The number of moons is too damn high!
 		
 		// - - - Loading tips - - -
 		

--- a/GameData/JNSQ/JNSQ_Localization/es-es.cfg
+++ b/GameData/JNSQ/JNSQ_Localization/es-es.cfg
@@ -1,5 +1,11 @@
 //Please note: I am not a professional translator, nor am I a native Spanish speaker. If there are mistakes do not hesitate to correct them!
 
+// The following 4 definitions are left untranslated. Please help with them:
+// - #LOC_JNSQ_Biome_WelcomeBackIsland
+// - #LOC_JNSQ_Biome_Whites
+// - #LOC_JNSQ_Biome_Basins
+// - #LOC_JNSQ_Biome_PolarIceCraters
+
 Localization
 {
 	es-es
@@ -52,12 +58,17 @@ Localization
 		#LOC_JNSQ_Biome_BrownMidlands = Tierras medias marrones
 		#LOC_JNSQ_Biome_BrownHighlands = Tierras altas Marrones
 		#LOC_JNSQ_Biome_EnclosedFaults = Fallas cerradas
+		#LOC_JNSQ_Biome_WelcomeBackIsland = Welcome Back Island
+		#LOC_JNSQ_Biome_Whites = Whites
+		#LOC_JNSQ_Biome_Basins = Basins
+
 		// Craters
 		#LOC_JNSQ_Biome_ExoticCraters = Cráteres exóticos
 		#LOC_JNSQ_Biome_RareCraters = Cráteres raros
 		#LOC_JNSQ_Biome_VoronoiCraters = Cráteres Voronoi
 		#LOC_JNSQ_Biome_NotableCraters = Cráteres notables
 		#LOC_JNSQ_Biome_Pockmarks = Pequeños cráteres
+		#LOC_JNSQ_Biome_PolarIceCraters = Polar Ice Craters
 		
 		// Oceans
 		#LOC_JNSQ_Biome_InlandWater = Aguas continentales
@@ -72,8 +83,10 @@ Localization
 		#LOC_JNSQ_Biome_KrenwichSea = Mar de Krenwich
 		#LOC_JNSQ_Biome_JoolwardSea = Jool-frente mar
 		#LOC_JNSQ_Biome_PolwardSea = Pol-frente mar
+
 		// Huygen
 		#LOC_JNSQ_Biome_MethaneLakes = Lagos de metano
+
 		// Eve
 		#LOC_JNSQ_Biome_PolarLakes = Lagos del polares
 		#LOC_JNSQ_Biome_PetrolLakes = Lagos de gasolina

--- a/GameData/JNSQ/JNSQ_Localization/es-es.cfg
+++ b/GameData/JNSQ/JNSQ_Localization/es-es.cfg
@@ -122,21 +122,21 @@ Localization
 		// - - - Mods - - -
 		
 		// ResearchBodies
-		#LOC_JNSQ_RBodies_discovery_Edna = Justo cuando pensábamos que Dres era la única gran cosa en el cinturón de asteroides.
-		#LOC_JNSQ_RBodies_discovery_Dak = Woah, Esta luna es realmente pequeña. Sinceramente, no esperábamos encontrarlo, pero nos alegra que esté donde está. ¿Crees que hay más?
-		#LOC_JNSQ_RBodies_discovery_Lindor = Hay un punto azul muy grande. Un punto azul realmente muy grande. ¡Es casi tan grande como Jool!
-		#LOC_JNSQ_RBodies_discovery_Krel = Hemos encontrado algo Parece increíblemente pequeño, pero está claramente orbitando al gigante. ¿Es un gran asteroide?
-		#LOC_JNSQ_RBodies_discovery_Aden = Encontramos una luna marrón. Encontramos muchas lunas marrones. Este sistema está oficialmente lleno de chispas de chocolate.
-		#LOC_JNSQ_RBodies_discovery_Huygen = ¡Hemos encontrado una luna grande y brillante de color amarillo! .... ¿Se ha estado escondiendo a la vista todo este tiempo?
-		#LOC_JNSQ_RBodies_discovery_Riga = Oh hola. Un objetivo muy considerable ha entrado en nuestras miras. Es lo suficientemente borroso como para tener una atmósfera también.
-		#LOC_JNSQ_RBodies_discovery_Talos = Esta luna es un poco manchada. Lo bueno es que es grande y fácil de detectar.
-		#LOC_JNSQ_RBodies_discovery_Hamek = Hay un píxel rojo fuerte. ¿Esta pantalla está muriendo? ¿O es así como es realmente este planeta?
-		#LOC_JNSQ_RBodies_discovery_Celes = ¿Qué es pequeño, oscuro y frío? Esta luna! Además, el trozo de carne que se congela en el refrigerador en el tercer piso.
-		#LOC_JNSQ_RBodies_discovery_Tam = Bruh. // Oh dear.
-		#LOC_JNSQ_RBodies_discovery_Nara = ¿Qué es esto? ¿Un planeta? ¡Pero está muy lejos! ¿Es pícaro? ¿O siempre ha estado aquí?
-		#LOC_JNSQ_RBodies_discovery_Amos = Wow esta luna es oscura! ¿Se formó a partir de una colisión?
-		#LOC_JNSQ_RBodies_discovery_Enon = ¡Pico del sensor detectado! Recalibrando. El albedo en esta luna es preocupantemente alto.
-		#LOC_JNSQ_RBodies_discovery_Prax = ¡Nara no puede ser un planeta pícara! ¡El número de lunas es demasiado alto!
+		#autoLOC_RBodies_discovery_Edna = Justo cuando pensábamos que Dres era la única gran cosa en el cinturón de asteroides.
+		#autoLOC_RBodies_discovery_Dak = Woah, Esta luna es realmente pequeña. Sinceramente, no esperábamos encontrarlo, pero nos alegra que esté donde está. ¿Crees que hay más?
+		#autoLOC_RBodies_discovery_Lindor = Hay un punto azul muy grande. Un punto azul realmente muy grande. ¡Es casi tan grande como Jool!
+		#autoLOC_RBodies_discovery_Krel = Hemos encontrado algo Parece increíblemente pequeño, pero está claramente orbitando al gigante. ¿Es un gran asteroide?
+		#autoLOC_RBodies_discovery_Aden = Encontramos una luna marrón. Encontramos muchas lunas marrones. Este sistema está oficialmente lleno de chispas de chocolate.
+		#autoLOC_RBodies_discovery_Huygen = ¡Hemos encontrado una luna grande y brillante de color amarillo! .... ¿Se ha estado escondiendo a la vista todo este tiempo?
+		#autoLOC_RBodies_discovery_Riga = Oh hola. Un objetivo muy considerable ha entrado en nuestras miras. Es lo suficientemente borroso como para tener una atmósfera también.
+		#autoLOC_RBodies_discovery_Talos = Esta luna es un poco manchada. Lo bueno es que es grande y fácil de detectar.
+		#autoLOC_RBodies_discovery_Hamek = Hay un píxel rojo fuerte. ¿Esta pantalla está muriendo? ¿O es así como es realmente este planeta?
+		#autoLOC_RBodies_discovery_Celes = ¿Qué es pequeño, oscuro y frío? Esta luna! Además, el trozo de carne que se congela en el refrigerador en el tercer piso.
+		#autoLOC_RBodies_discovery_Tam = Bruh. // Oh dear.
+		#autoLOC_RBodies_discovery_Nara = ¿Qué es esto? ¿Un planeta? ¡Pero está muy lejos! ¿Es pícaro? ¿O siempre ha estado aquí?
+		#autoLOC_RBodies_discovery_Amos = Wow esta luna es oscura! ¿Se formó a partir de una colisión?
+		#autoLOC_RBodies_discovery_Enon = ¡Pico del sensor detectado! Recalibrando. El albedo en esta luna es preocupantemente alto.
+		#autoLOC_RBodies_discovery_Prax = ¡Nara no puede ser un planeta pícara! ¡El número de lunas es demasiado alto!
 		
 		// - - - Loading tips - - -
 				

--- a/GameData/JNSQ/JNSQ_Localization/it-it.cfg
+++ b/GameData/JNSQ/JNSQ_Localization/it-it.cfg
@@ -1,3 +1,9 @@
+// The following 4 definitions are left untranslated. Please help with them:
+// - #LOC_JNSQ_Biome_WelcomeBackIsland
+// - #LOC_JNSQ_Biome_Whites
+// - #LOC_JNSQ_Biome_Basins
+// - #LOC_JNSQ_Biome_PolarIceCraters
+
 Localization
 {
 	it-it
@@ -50,12 +56,17 @@ Localization
 		#LOC_JNSQ_Biome_BrownMidlands = Regioni Marroni
 		#LOC_JNSQ_Biome_BrownHighlands = Prominenze Marroni
 		#LOC_JNSQ_Biome_EnclosedFaults = Faglie Racchiuse
+		#LOC_JNSQ_Biome_WelcomeBackIsland = Welcome Back Island
+		#LOC_JNSQ_Biome_Whites = Whites
+		#LOC_JNSQ_Biome_Basins = Basins
+
 		// Crateri
 		#LOC_JNSQ_Biome_ExoticCraters = Crateri Esotici
 		#LOC_JNSQ_Biome_RareCraters = Crateri Rari
 		#LOC_JNSQ_Biome_VoronoiCraters = Crateri di Voronoi
 		#LOC_JNSQ_Biome_NotableCraters = Crateri Notevoli
 		#LOC_JNSQ_Biome_Pockmarks = Cavità
+		#LOC_JNSQ_Biome_PolarIceCraters = Polar Ice Craters
 		
 		// Oceani
 		#LOC_JNSQ_Biome_InlandWater = Acque Interne
@@ -70,8 +81,10 @@ Localization
 		#LOC_JNSQ_Biome_KrenwichSea = Mare di Krenwich
 		#LOC_JNSQ_Biome_JoolwardSea = Mare di Jool
 		#LOC_JNSQ_Biome_PolwardSea = Mare di Pol
+
 		// Huygen
 		#LOC_JNSQ_Biome_MethaneLakes = Laghi di Metano
+
 		// Eve
 		#LOC_JNSQ_Biome_PolarLakes = Laghi Polari
 		#LOC_JNSQ_Biome_PetrolLakes = Laghi di Petrolio

--- a/GameData/JNSQ/JNSQ_Localization/it-it.cfg
+++ b/GameData/JNSQ/JNSQ_Localization/it-it.cfg
@@ -120,21 +120,21 @@ Localization
 		// - - - Mod - - -
 		
 		// ResearchBodies
-		#LOC_JNSQ_RBodies_discovery_Edna = E pensare che eravamo convinti solo Dres fosse svariate miglia più grande di qualsiasi altro oggetto nella cintura degli asteroidi.
-		#LOC_JNSQ_RBodies_discovery_Dak = Wow. Questa luna è davvero piccola. Non ci aspettavamo di trovarla, onestamente, ma siamo lieti che sia in questo punto. Pensate ce ne siano altre?
-		#LOC_JNSQ_RBodies_discovery_Lindor = C'è un puntino blu estremamente grande. Ma veramente molto grande. É grande quasi quanto Jool!
-		#LOC_JNSQ_RBodies_discovery_Krel = Abbiamo trovato qualcosa. É incredibilmente piccolo, ma orbita quel gigante gassoso. É un asteroide gigante?
-		#LOC_JNSQ_RBodies_discovery_Aden = Abbiamo trovato un puntino marrone. Ne abbiamo trovati un sacco. Questo sistema è ufficialmente pieno di scaglie di cioccolato.
-		#LOC_JNSQ_RBodies_discovery_Huygen = Abbiamo individuato una brillante luna gialla di considerevoli dimensioni! .... Com'è che ce ne siamo accorti solo ora?
-		#LOC_JNSQ_RBodies_discovery_Riga = Hey buongiorno. Un oggetto di grandi dimensioni è appena entrato nella nostra visuale. É sfocato abbastanza che probabilmente ha anche un'atmosfera.
-		#LOC_JNSQ_RBodies_discovery_Talos = Questa luna è un po' maculata. Fortuna che è grande e facile da individuare.
-		#LOC_JNSQ_RBodies_discovery_Hamek = Uno dei pixel è diventato rosso. É lo schermo che si è danneggiato? O c'è davvero un pianeta di quel colore?
-		#LOC_JNSQ_RBodies_discovery_Celes = Cos'è piccola, scura e fredda? Questa luna! E anche quella fetta di carne che si sono dimenticati nel freezer del terzo piano.
-		#LOC_JNSQ_RBodies_discovery_Tam = Ma che roba è???
-		#LOC_JNSQ_RBodies_discovery_Nara = Cos'è? Un pianeta? Ma è distantissimo da Lindor! Che sia un pianeta orfano? O c'è sempre stato?
-		#LOC_JNSQ_RBodies_discovery_Amos = Wow questa luna è scurissima! Che sia un pezzo staccatosi dal pianeta lì vicino?
-		#LOC_JNSQ_RBodies_discovery_Enon = I sensori hanno registrato un'impennata! Ricalibrazione. L'albedo di questa luna raggiunge livelli preoccupanti.
-		#LOC_JNSQ_RBodies_discovery_Prax = Nara non può essere un pianeta orfano! Il numero di lune è assurdamente elevato.
+		#autoLOC_RBodies_discovery_Edna = E pensare che eravamo convinti solo Dres fosse svariate miglia più grande di qualsiasi altro oggetto nella cintura degli asteroidi.
+		#autoLOC_RBodies_discovery_Dak = Wow. Questa luna è davvero piccola. Non ci aspettavamo di trovarla, onestamente, ma siamo lieti che sia in questo punto. Pensate ce ne siano altre?
+		#autoLOC_RBodies_discovery_Lindor = C'è un puntino blu estremamente grande. Ma veramente molto grande. É grande quasi quanto Jool!
+		#autoLOC_RBodies_discovery_Krel = Abbiamo trovato qualcosa. É incredibilmente piccolo, ma orbita quel gigante gassoso. É un asteroide gigante?
+		#autoLOC_RBodies_discovery_Aden = Abbiamo trovato un puntino marrone. Ne abbiamo trovati un sacco. Questo sistema è ufficialmente pieno di scaglie di cioccolato.
+		#autoLOC_RBodies_discovery_Huygen = Abbiamo individuato una brillante luna gialla di considerevoli dimensioni! .... Com'è che ce ne siamo accorti solo ora?
+		#autoLOC_RBodies_discovery_Riga = Hey buongiorno. Un oggetto di grandi dimensioni è appena entrato nella nostra visuale. É sfocato abbastanza che probabilmente ha anche un'atmosfera.
+		#autoLOC_RBodies_discovery_Talos = Questa luna è un po' maculata. Fortuna che è grande e facile da individuare.
+		#autoLOC_RBodies_discovery_Hamek = Uno dei pixel è diventato rosso. É lo schermo che si è danneggiato? O c'è davvero un pianeta di quel colore?
+		#autoLOC_RBodies_discovery_Celes = Cos'è piccola, scura e fredda? Questa luna! E anche quella fetta di carne che si sono dimenticati nel freezer del terzo piano.
+		#autoLOC_RBodies_discovery_Tam = Ma che roba è???
+		#autoLOC_RBodies_discovery_Nara = Cos'è? Un pianeta? Ma è distantissimo da Lindor! Che sia un pianeta orfano? O c'è sempre stato?
+		#autoLOC_RBodies_discovery_Amos = Wow questa luna è scurissima! Che sia un pezzo staccatosi dal pianeta lì vicino?
+		#autoLOC_RBodies_discovery_Enon = I sensori hanno registrato un'impennata! Ricalibrazione. L'albedo di questa luna raggiunge livelli preoccupanti.
+		#autoLOC_RBodies_discovery_Prax = Nara non può essere un pianeta orfano! Il numero di lune è assurdamente elevato.
 		
 		// - - - Loading tips - - -
 		

--- a/GameData/JNSQ/JNSQ_Localization/zh-cn.cfg
+++ b/GameData/JNSQ/JNSQ_Localization/zh-cn.cfg
@@ -1,0 +1,171 @@
+Localization
+{
+	zh-cn
+	{
+		// Descriptions
+		#LOC_JNSQ_Aden_desc = 就像俗话说的那样，Aden是Lindor手里握着的一枚小小的棕色玻璃弹珠。它看起来很像Mun或Edna那样的岩石星球，但它离Lindor很近，表明它的内部可能非常不同。\n\n呃……反正那些留着爆炸头的老科学家就是让我这么写的。//Aden is a small brown marble sitting in Lindor's preverbial hand. It seems like a rocky world much like the Mun or Edna but its proximity to Lindor suggests it may be very different inside. Well, that's what the old scientists with afros said to write for this.
+		#LOC_JNSQ_Amos_desc = Amos是Nara最内侧的卫星，它与后者表面的暗色调相同，显得神出鬼没。\n\n就像人们通常以貌取人一样，从外观判断，Amos具有独特的组成成分。//The elusive innermost moon of Nara, Amos shares in the darker tones of Nara's surface and may have a unique composition if it is correctly judged just as a book may often be judged by its cover.
+		#LOC_JNSQ_Bop_desc = Bop棕色又浑圆，“啵”声处处有耳闻。//Bop is brown. Bop is round. Bop is the sound that was heard all around.
+		#LOC_JNSQ_Celes_desc = 非常巧合的是，这个曾被称为KB 4500331的天体，被命名为Celes。人们经常争论，假如Eeloo不存在的话，Celes能否自成一颗矮行星，而不是卫星。人们也认为它是以探测动力有限公司的一名注重安全的著名软件工程师命名的。\n\n当媒体采访Kuiper Kerman和Celes Kerman时，他们都回答“无可奉告”，并拒绝回答更多问题。//It comes as a great coincidence that this body, prviously known as KB 4500331 was given the alias of Celes. It is often argued whether Celes could be its own dwarf planet and not a moon if Eeloo wasn't around. It is also argued to be named after a prominent, safety-minded software engineer at Probodobodyne. When Kuiper Kerman and Celes Kerman were approached by media teams they both responded 'NDA' and declined further questions.
+		#LOC_JNSQ_Dak_desc = 有些土豆小又小，有些土豆高又高。Dak这个土豆会发出女妖的呼号。//Some potatoes are small. Some potatoes are tall. Dak is a potato with a siren's call.
+		#LOC_JNSQ_Dres_desc = Dres苍白、硕大、貌不惊人，人们对它熟视无睹。以半径和引力范围来衡量，Dres都是内小行星带中已知的最大天体。经过充分观测，Dres被证实在大小和密度上都与Mun相似；它也是仅次于Hamek的最孤独的天体。//Pale, large, and seemingly unattractive, Dres hides in plain sight. It is the largest known body in the inner asteroid belt, measured by both radius and gravioli serving size. Dres has been observed enough to be confirmed as Mun-like in size and density, and also to be the loneliest world around, second to Hamek.
+		#LOC_JNSQ_Duna_desc = Duna是一颗奇特的暖色调行星。令人惊讶的是，它的大气层很贫乏，这跟它拥有冰盖的能力发生了矛盾。\n\n坎巴拉天文协会确信Duna很容易到达（与Eve形成鲜明对比），因此渴望在这个大方向上启动第一批载人探险，越快越好。//Duna is a curiously warm-colored planet. Its surprising lack of atmosphere clashes strongly with its ability to host what very surely are ice caps. The Kerbal Astronomical Society is confident that Duna is very approachable, in great constrast to Eve, and so is eager to launch the first several crewed expeditions in this general direction ASAP.
+		#LOC_JNSQ_Edna_desc = Edna是小行星带中一个孤寂黑暗的天体，很可能是以一位脾气暴躁的女科学家命名的。它比Dres更难认定为行星。\n\n坎巴拉天文学家最终意识到，与附近的大型小行星不同，Edna特别圆，而且会少见但有规律地遮挡其他天体或被其他天体遮挡。//A lonely and dark world within the local asteroid belt, most likely named after a very grumpy female scientist, Edna turned out to be harder to recognize as a planet than Dres was. Kerbal astronomers eventually realized that unlike any of the large asteroids around, Edna was particularly round, and that it would, in few but regular cases, occlude something or be occluded.
+		#LOC_JNSQ_Eeloo_desc = 作为冰行星的典型代表，Eeloo十分洁白，你一旦清楚地观察到了它就很难移开视线。\n\n它拥有巨大的重力井，这使得坎巴拉科学家相信宇宙的很大一部分可能是由冰淇淋球组成的。//Eeloo, the poster-child for ice worlds, is remarkably white and very difficult to look away from once clearly observed. It hosts a significant gravity well and encourages kerbal scientists to believe that a significant portion of the cosmos may consist of ice cream scoops.
+		#LOC_JNSQ_Enon_desc = 当你在离家园如此之远的地方冒险时，除了尝尝冰是啥味儿外，再没什么可期待的了……\n\n不过当你遇到了一个几乎跟Duna一样大的白色卫星时，事情就变得有趣了起来。//Little is to be expected other than flavors of ice when one ventures this far from home... But things can get interesting nonetheless, when one encounters a white moon nearly as large as Duna.
+		#LOC_JNSQ_Eve_desc = Eve是一颗特别紫的行星，大概是拥有足够多的某种稀有物质，给它的海洋和大地染上了紫色；就像一滴添加剂就能明显地改变一杯果汁的味道那样。\n\n所幸（至少目前）还没有人声称Eve上充满了葡萄汁。//Eve is an exceptionally purple planet, presumably possessing just enough of a rare substance to tint its oceans and horizons, like how one drop of any additive can remarkably change the flavor of a mug of juice. Fortunately, nobody has made the claim...yet, that Eve is full of grape juice.
+		#LOC_JNSQ_Gilly_desc = Giily是一块徘徊在Eve轨道附近的大石头。长期以来，它曾被认为是坎巴拉天文协会发现的最小的天然卫星。\n\n然而，当小行星带殖民的概念突然开始引起那些无所畏惧的人的兴趣时，事情就起了变化。//Gilly is a lumpy rock wandering around the orbit of Eve. It was once and for a long time believed to be the smallest natural satellite that the Kerbal Astronomical Society ever discovered, but that changed when the concept of colonizing the asteroid field suddenly became very interesting to those who weren't afraid of it.
+		#LOC_JNSQ_Hamek_desc = 这个色彩奇异的天体在柯伊伯·科尔曼带的深处摇摆回旋、时隐时现。\n\n人们普遍认为，在离太阳如此遥远的距离上只能存在冰行星，因此目前完全无法解释Hamek的红色。//This wonderfully mis-colored world dances and sways in and out of the depths of Kuiper Kerman's Belt. At this level of distance, expectation is high that only ice planets can exist here, so Hamek's redness is currently beyond all reason.
+		#LOC_JNSQ_Huygen_desc = Huygen拥有浓厚、朦胧的大气层和独特的琥珀色光泽。它令天文学家们绞尽脑汁，甚至有点害怕，因为他们发现它的时间太短了，短得让人恼火。\n\n这颗卫星的环境究竟是像Eve一样恶劣还是看似宜人，还有待证实。//With thick, hazy atmosphere and distinct amber sheen, Huygen has kept astronomers thinking hard, and somewhat scared, for the annoyingly short time scale by which they've been aware of it. Whether this moon is as hostile as Eve or deceptively quite approachable waits to be confirmed.	
+		#LOC_JNSQ_Ike_desc = 一个苍白的球体隐现在这颗看似荒凉的行星的天空，很像照耀着坎巴拉人的那个球体，可能起到的作用也完全一样。\n\n人们举头望Mun，不禁问道：为什么Ike竟能如此相像？//A pale sphere looms over the seeming desolate red planet, much like the one that has always been near to kerbal-kind and possibly serving all of the exact same purposes. Why, asks the Mun-gazers, is Ike so alike?
+		#LOC_JNSQ_Jool_desc = 就尺寸而言，Jool是太阳系中最巨大的行星；就成分而言，它跟Kerbin并列为最丰富的天体。它的主色调与坎巴拉人的肤色令人费解地相同，它的卫星多样性之广迄今无与伦比。因此Jool成了坎巴拉人关于行星际乃至恒星际殖民的主要灵感来源。//By sheer size, Jool stands the tallest among the local planets, and it ties with Kerbin for the title of richest celestial body (by composition). Its primary color is inexplicably the same as the skin of a kerbal, and the variety among its moons is exceedingly wide and unparalleled to date, making Jool the chief source of inspiration to Kerbal-kind for interplanetary and eventually, interstellar colonization.
+		#LOC_JNSQ_Kerbin_desc = Kerbin是一个蓝绿色相间的奇妙星球，是已知的唯一孕育出不仅仅有本能行为的智慧生命形态的行星。\n\n现在，这些自称为“坎巴拉人”的生命形态正试图走出摇篮、踏足深空。而他们只要入轨，就能完成面临的巨大挑战的一半。他们能成功吗？//A wondrous green and blue world, Kerbin is the only planet known to have given rise to life forms capable of more than instinctive action. Now these life forms, calling themselves Kerbals, seek to depart their nest and set foot in the deep. Half of the grand challenge ahead of them is just getting into orbit. Will they make it?
+		#LOC_JNSQ_Krel_desc = 这个小天体环绕母星的轨道非常接近，难以分辨，直到一位首席天文学家弄丢了他的望远镜，不得不买了一部更先进的。\n\n当他注意到Krel那皱纹遍布的外貌时，他开始为自己的年龄而忧虑。//This small pale world orbits its parent very closely, and was very hard to distinguish until a lead astronomer lost his telescope and had to obtain a new and shinier one. He became very concerned for his age when he noted Krel's veiny appearance.
+		#LOC_JNSQ_Laythe_desc = 这颗绿色巨行星的荣耀一半在于那颗迄今为止观测到的最大最重的卫星。\n\n只要想到Laythe，人们很容易提出一些难以回答的问题，比如：为什么这么像？我们怎么去那里？它能免受Jool辐射的影响吗？我们什么时候可以出发？我们到那里后能做出同样美味的零食，而不用永远靠脱水食品度日吗？//Half of the green giant's glory rests in what is the widest and heaviest moon observed yet. The hard questions easily arise at the thought of Laythe, such as: Why? How? Is it safe from Jool's radiation? How soon can we go? Can we make snacks just as good once we get there and not live on dehydrated stuff forever?
+		#LOC_JNSQ_Lindor_desc = Lindor是第六大行星，体积大得惊人，类型与Jool相同。它的漩涡更微弱、更平静，带给观察者一种特别安宁的感觉。\n\n最近有人提出了一个关键的问题：Lindor到底含有水还是巧克力？//The sixth major planet, Lindor is amazingly large and is the same kind as Jool. Its swirls are fainter and calmer, instilling a particularly restful feeling into onlookers. A critical question has been raised recently- whether Lindor contains water or chocolate.
+		#LOC_JNSQ_Minmus_desc = Minmus相当小，相当远，相当绿。自手工食品诞生以来，人们就相信它是由冰淇淋或薄荷组成的。但最近一些人醒过味了，开始假设它其实可能是个生锈的球。\n\n然而，这一观点被提到时往往会引发政党辩论般的扯皮。//Minmus is rather small, rather distant, and rather green. As long as artisan food has existed, so has the belief that it is composed of ice cream or mint. But recently, some have wised up and begun assuming it may actually be a rust ball. Mentioning this, however, tends to lead to levels of conflict only seen in debates between two political alignments.
+		#LOC_JNSQ_Moho_desc = 这颗最内侧的行星就像一个坎巴拉人智者，晒了太多日光浴然后被他的小孙子泼了一身水——话说回来，他也没那么智慧是吧？\n\n看起来，Moho比太阳系其他行星经历了更多，受到的惩罚也更多。看看那些条纹吧！想想Moho可能隐藏着什么样的秘密吧！再想想那里有多热吧！//The innermost planet is as a wise kerbal who sun-bathed too much and then got splashed by their grandchildren. Actually, that's not very wise, now is it? ...Moho has seen a lot and taken more punishment than the other local planets, so it appears. Look at those streaks! Think of what Moho might be secretly carrying now! And think of the heat too!
+		#LOC_JNSQ_Mun_desc = 亘古以来，一个苍白的球体就隐现在坎巴拉人的天空，照亮他们的夜晚，翻搅他们的海洋。人们亲切地称它为 "Mün"。它就像后院树上高悬的果实一样，蕴藏着惊喜等待被人发现。//A pale sphere looms over Kerbal-kind since time immemorial, lighting their nights and stirring their oceans. Affectionately called Mün, it hosts pleasant suprises waiting to be found, like high hanging fruit in the tree of their back yard.
+		#LOC_JNSQ_Nara_desc = 在古典天文学中，当人们密切关注那个被后世称为柯伊伯·科尔曼带的地方时，可以明显发现有很多轨道十分奇怪：有什么东西在搅动那些冰小行星，就像搅动燃料罐里的液氧，但效果相反。坎巴拉天文协会终于意识到，那里有个引力足以与Jool和Lindor匹敌的东西，在干扰着前者无法触及的小天体。\n\n当Nara悄然进入可观测范围时，它看起来只是另一个KB小天体；但它的速度慢到自成一数量级，这表明它可能是个遥远的庞然大物。//In classical astronomy, when close attention was paid to what would be known as Kuiper Kerman's Belt, it became apparent that there were many odd orbits, that something was stirring the ice asteroids like the LOX in a tank but having the opposite effect. The Kerbal Astronomical Society eventually realized that there was something out there with enough gravity to rival Jool and Lindor, and disturb the minor worlds beyond their reach. As Nara crept into observable ranges, it seemed like just another KB member, but the lack of apparent velocity was on a magnitude of its own, revealing its potential to be gigantic.
+		#LOC_JNSQ_Pol_desc = 某些为卫星命名的科学家是最有求知欲的一类人。Pol这个名字是一位非常重视植物学的科学家起的。也许，Pol的成分同样非常适合外星农业。//The scientists who get to name some of these moons are the most curious kind. Pol earns its name from one who takes botany very seriously. Perhaps Pol's composition will similarly lend itself very well to off-world agriculture.
+		#LOC_JNSQ_Prax_desc = 在历史中，坎巴拉人已经发现了一些伟大的真理。Prax的存在就展示了这样一个真理——每个巨大的母行星都有一个边缘世界环绕着它。//In the history of kerbal-kind several great truths have been discovered. Prax itself is an example of that truth... Every great parent planet has a fringe world beside it.
+		#LOC_JNSQ_Riga_desc = Riga是Lindor手里最大的一枚玻璃弹珠，也被认为是最有趣的一枚。它因其尺寸和其他可观测特征而有趣，正如Tylo之于Jool的其他卫星一样。它表面的大部分甚至跟Kerbin有种微妙而明显的相似性。//The largest brown marble in Lindor's hand, Riga is deemed the most interesting of them all. Its size and other observable characteristics make it as interesting as Tylo among Jool's moons. A large portion of its surface even has a subtle but clear familiarity to Kerbin.
+		#LOC_JNSQ_Sun_desc = 太阳。它是能量，它是生命，它是热度，它是坎巴拉人小小宇宙的中心。\n\n几个世纪以来，坎巴拉的工程师和科学家都逐渐意识到，有一天他们可以把像太阳一样的东西装在脚下，无尽燃烧、永不减弱，推动他们飞升和超越，支持他们走向寒冷孤独的无垠太空。//The Sun. It is power, it is life, it is heat, and it is the center of Kerbal-kind's little universe. Kerbal engineers and scientists alike have grown to realize over the centuries, that one day, they can have something like the Sun under them, burning endlessly without dwindling, propelling them above and beyond, and sustaining them in the cold and lonely expanse.
+		#LOC_JNSQ_Talos_desc = 我们对Talos的唯一认知偏差是它与Riga或Lindor的距离。它接近水平的轨道倾角表明，它要么是形成在这里的，要么是被捕获后迅速稳定了下来。\n\n如果有人去那里对它进行取样，可能会从它鲜明的色彩中取得许多科学成果。//The only thing that's far off about Talos is its distance from Riga or from Lindor. Its near neutral inclination suggests that it either formed here or was quickly stabilized after being captured. Its strong colorations may yield much scientific fruit when someone gets out there to sample it.
+		#LOC_JNSQ_Tam_desc = 柯伊伯·科尔曼的腰带上有很多缺口和一个很宽的带扣，像Tam一样的小东西就会通过这些缺口出现。坎巴拉人没有批评他系着这么大的腰带，反而大都称赞了他古怪的时尚感，正如他们称赞他致力于寻找和命名柯伊伯带小天体一样。\n\nTam在同类小天体中绝非独一无二，但它确实是迄今唯一发现的被更大天体捕获的。在Tam得到自己的名字之前，它被分配了一个代号KB 4089848；这样的代号通常是分配给同类中更有趣者的。//Kuiper Kerman's belt has many notches and a very wide buckle. Little things like Tam appear through these notches, and kerbals who don't criticize him for wearing such a large belt do praise his eccentric fashion sense on the whole just as they praise his devotion to finding and naming the little things out there. Tam is far from the only one of its kind but it's the only one found captured by a larger body to date. Before Tam got its personal name, it carried a designation often given to the more interesting of its kind. For Tam it was KB 4089848.
+		#LOC_JNSQ_Tylo_desc = Tylo苍白而巨大，与Laythe争夺着世人的注意力。从表面上看，这个干旱的天体没什么可期待的。但在Jool的影响下，它可能比想象中更有趣。//Pale and large, Tylo fights for the spotlight with Laythe. As an arid world, there is little to look forward to when taken at face value. But in Jool's influence, there may be more than meets the eye.
+		#LOC_JNSQ_Vall_desc = Vall是一个奇特的无大气蓝色天体。奇怪的是，它是最后一个被发现的Jool卫星，因为它每次被观测到时都会被误认为是内小行星带中的一颗暗淡的小行星。//Vall is a curiously blue airless body and curiously, the last of them to be discovered, having been often mistaken for a pale asteroid in the inner asteroid belt whenever it was observed.
+		
+		// Surface
+		#LOC_JNSQ_Biome_Trenches = 沟壑
+		#LOC_JNSQ_Biome_NotableMountains = 显眼的山脉
+		#LOC_JNSQ_Biome_NotablePlains = 显眼的平原
+		#LOC_JNSQ_Biome_Volcano = 火山
+		#LOC_JNSQ_Biome_AridLowlands = 干旱低地
+		#LOC_JNSQ_Biome_AridMidlands = 干旱内陆
+		#LOC_JNSQ_Biome_AridHighlands = 干旱高原
+		#LOC_JNSQ_Biome_AridMountains = 干旱山脉
+		#LOC_JNSQ_Biome_BrownBasins = 棕色盆地
+		#LOC_JNSQ_Biome_BrownLowlands = 棕色低地
+		#LOC_JNSQ_Biome_BrownMidlands = 棕色内陆
+		#LOC_JNSQ_Biome_BrownHighlands = 棕色高原
+		#LOC_JNSQ_Biome_EnclosedFaults = 封闭断层
+		#LOC_JNSQ_Biome_WelcomeBackIsland = 欢迎回家岛
+		#LOC_JNSQ_Biome_Whites = 白土
+		#LOC_JNSQ_Biome_Basins = 盆地
+
+		// Craters
+		#LOC_JNSQ_Biome_ExoticCraters = 奇异环形山
+		#LOC_JNSQ_Biome_RareCraters = 罕见环形山
+		#LOC_JNSQ_Biome_VoronoiCraters = 沃罗诺伊环形山
+		#LOC_JNSQ_Biome_NotableCraters = 显眼的环形山
+		#LOC_JNSQ_Biome_Pockmarks = 凹坑
+		#LOC_JNSQ_Biome_PolarIceCraters = 极地冰环形山
+		
+		// Oceans
+		#LOC_JNSQ_Biome_InlandWater = 内陆湖
+		#LOC_JNSQ_Biome_GreatLakes = 大湖
+		#LOC_JNSQ_Biome_ArcticSea = 北极海
+		#LOC_JNSQ_Biome_Sub-ArcticSea = 副北极海
+		#LOC_JNSQ_Biome_ForemansSea = 福尔曼海
+		#LOC_JNSQ_Biome_TriangulusSea = 三角海
+		#LOC_JNSQ_Biome_NorthernSea = 北海
+		#LOC_JNSQ_Biome_EasternSea = 东海
+		#LOC_JNSQ_Biome_WesternSea = 西海
+		#LOC_JNSQ_Biome_KrenwichSea = 克伦维奇海
+		#LOC_JNSQ_Biome_JoolwardSea = 向Jool之海
+		#LOC_JNSQ_Biome_PolwardSea = 向Pol之海
+
+		// Huygen
+		#LOC_JNSQ_Biome_MethaneLakes = 甲烷湖
+		
+		// Eve
+		#LOC_JNSQ_Biome_PolarLakes = 极地湖
+		#LOC_JNSQ_Biome_PetrolLakes = 汽油湖
+		#LOC_JNSQ_Biome_KrakensWell = 海妖之井
+		#LOC_JNSQ_Biome_SeaofAkron = 阿克伦海
+		#LOC_JNSQ_Biome_SeaofNessus = 涅索斯海
+		#LOC_JNSQ_Biome_SeaofTaniwha = 坦尼瓦海
+		#LOC_JNSQ_Biome_SeaofGigan = 盖刚海
+		#LOC_JNSQ_Biome_SeaofRodan = 拉顿海
+		#LOC_JNSQ_Biome_SeaofGojira = 哥斯拉海
+		#LOC_JNSQ_Biome_SeaofGhidorah = 基多拉海
+		#LOC_JNSQ_Biome_SeaofBagorah = 巴哥拉海
+		
+		// Gas Giants
+		#LOC_JNSQ_Biome_EquatorialBands = 赤道带
+		#LOC_JNSQ_Biome_TemperateBands = 温带
+		#LOC_JNSQ_Biome_ExposedLowerDeck = 裸露下层
+		#LOC_JNSQ_Biome_SubpolarBands = 副极地带
+		#LOC_JNSQ_Biome_StormComplex = 风暴复合体
+		#LOC_JNSQ_Biome_UpperStormDeck = 上层风暴层
+		
+		// Sun
+		#LOC_JNSQ_Biome_NorthPolarZone = 北极区
+		#LOC_JNSQ_Biome_NorthSubpolarZone = 副北极区
+		#LOC_JNSQ_Biome_NorthTemperateZone = 北温带区
+		#LOC_JNSQ_Biome_NorthTropicZone = 北热带区
+		#LOC_JNSQ_Biome_EquatorialZone = 赤道区
+		#LOC_JNSQ_Biome_SouthTropicZone = 南热带区
+		#LOC_JNSQ_Biome_SouthTemperateZone = 南温带区
+		#LOC_JNSQ_Biome_SouthSubpolarZone = 副南极区
+		#LOC_JNSQ_Biome_SouthPolarZone = 南极区
+		
+		// - - - Mods - - -
+		
+		// ResearchBodies （原作者把以下变量名错写成了#LOC_JNSQ_RBodies_discovery_*。若原作者有修复，需相应地改回去）
+		#autoLOC_RBodies_discovery_Edna = 就在我们以为Dres是小行星带中唯一的比其他东西大得多的天体时。//Just when we though Dres was alone in being leagues larger than anything in the asteroid belt.
+		#autoLOC_RBodies_discovery_Dak = 哇哦，这颗卫星好小。说实话，我们都没想到能发现它，不过我们还是很高兴它就在那里。你觉得我们还能发现更多吗？//Woah. This moon is really small. We didn't expect to find it, honestly, but we're glad it is where it is. Do you think there is more of it?
+		#autoLOC_RBodies_discovery_Lindor = 那是个很大的蓝点，很、大、很、大、的蓝点。几乎跟Jool一样大！//There's a really large blue dot. A really really large blue dot. It's nearly as big as Jool!
+		#autoLOC_RBodies_discovery_Krel = 我们发现了一些东西。它看起来非常小，但显然是在环绕那颗巨行星运行。那是颗大号小行星吗？//We've found something. Seems incredibly small but it's clearly orbiting the giant. Is it a huge asteroid?
+		#autoLOC_RBodies_discovery_Aden = 我们发现了一个棕色小点。我们已经发现好多棕色小点了。实锤了，这个太阳系充满了巧克力豆。//We found a brown dot. We found a lot of brown dots. This system is officially full of chocolate chips.
+		#autoLOC_RBodies_discovery_Huygen = 我们发现了一颗挺大的亮黄色卫星！……我们怎么现在才发现它？//We've spotted a bright and sizable yellow moon! .... How are we only now noticing it?
+		#autoLOC_RBodies_discovery_Riga = 看啊，一个挺大的目标进入了我们的视线。它很模糊，可能也有大气层。//Oh hello. A very sizable target has entered our sights. It's fuzzy enough to possibly have an atmosphere too.
+		#autoLOC_RBodies_discovery_Talos = 这颗卫星有点斑斑点点的。好在它还挺大的，容易被发现。//This moon is a bit splotchy. Good thing it's big and easy to spot.
+		#autoLOC_RBodies_discovery_Hamek = 这有个显眼的红色像素，是屏幕坏点吗？还是这颗行星就长这样？//There's a strong red pixel. Is this screen dying? Or is that actually how this planet is?
+		#autoLOC_RBodies_discovery_Celes = 什么东西又小、又黑、又冷？这颗卫星！……以及，三楼冰箱里那块冻坏了的肉。//What's small, dark, and cold? This moon! Also, the chunk of meat that's getting freezer-burn in the fridge on 3rd floor.
+		#autoLOC_RBodies_discovery_Tam = 嗐。//Bruh. // Oh dear.
+		#autoLOC_RBodies_discovery_Nara = 这是啥，一颗行星吗？可它比Lindor还要远那么多！这是一颗路过的流浪行星，还是一直都在我们太阳系？//What's this? A planet? But it's so far past Lindor! Is it rogue? Or has it always been here?
+		#autoLOC_RBodies_discovery_Amos = 这颗卫星好暗啊！它是从母星掉出来的一个碎块吗？//Wow this moon is dark! Is it a chip off of its parent's block?
+		#autoLOC_RBodies_discovery_Enon = 检测到传感器尖峰！重新校准。这颗卫星的反照率相当高。//Sensor spike detected! Recalibrating. The albedo on this moon is concerningly high.
+		#autoLOC_RBodies_discovery_Prax = 它的主行星不可能是流浪行星！因为卫星的数量也太TM多了！//The main planet can't be rogue! The number of moons is too damn high!
+		
+		// - - - Loading tips - - -
+		
+		#LOC_JNSQ_Tip01 = 正在发现生态群系…
+		#LOC_JNSQ_Tip02 = 正在排练新剧本…
+		#LOC_JNSQ_Tip03 = 正在删除所有包含字符串"SSTO"的载具文件…
+		#LOC_JNSQ_Tip04 = 正在研究天体…
+		#LOC_JNSQ_Tip05 = 正在翻新行星…
+		#LOC_JNSQ_Tip06 = 正在更优地优化系统…
+		#LOC_JNSQ_Tip07 = 正在等待截图…
+		#LOC_JNSQ_Tip08 = 正在（再一次）重新发明这个游戏…
+		#LOC_JNSQ_Tip09 = 正在扣上柯伊伯带…
+		#LOC_JNSQ_Tip10 = 正在计算延长的滑翔降落轨迹…
+		#LOC_JNSQ_Tip11 = 正在观测第九行星…
+		#LOC_JNSQ_Tip12 = 正在刺探敌对太空计划的情报…
+		#LOC_JNSQ_Tip13 = 正在检测为Eve优化的引擎…
+		#LOC_JNSQ_Tip14 = 正在统计安装的SpaceTux模组数量…
+		#LOC_JNSQ_Tip15 = 正在种植土豆…
+		#LOC_JNSQ_Tip16 = 正在请求Damon添加更多的太空中心…
+		#LOC_JNSQ_Tip17 = 正在将Jebediah Kerman停职…
+		#LOC_JNSQ_Tip18 = 正在建立城市…
+		#LOC_JNSQ_Tip19 = 正在提高ΔV需求…
+		#LOC_JNSQ_Tip20 = 正在不加载SquadExpansion/MakingHistory/…
+		#LOC_JNSQ_Tip01 = 正在霸占Umbra Space Industries模组的素材…
+		#LOC_JNSQ_Tip22 = 正在保证提供新鲜零食！…
+		#LOC_JNSQ_Tip23 = 正在下载更少内存…
+		#LOC_JNSQ_Tip24 = 正在劫持天空盒…
+		#LOC_JNSQ_Tip25 = 正在管理模块…
+		#LOC_JNSQ_Tip26 = 正在海边捡椰子…
+		#LOC_JNSQ_Tip27 = 正在停泊驳船…
+		#LOC_JNSQ_Tip28 = 正在装入更多载荷…
+		#LOC_JNSQ_Tip29 = 正在监测二氧化碳水平…
+		#LOC_JNSQ_Tip30 = 正在委派更多新人宇航员…
+		#LOC_JNSQ_Tip31 = 正在烧蚀得更猛烈些…
+		#LOC_JNSQ_Tip32 = 正在释放蜻蜓号无人机…
+		#LOC_JNSQ_Tip33 = 正在为系统补充水…
+		#LOC_JNSQ_Tip34 = 正在签下新的合同…
+		#LOC_JNSQ_Tip35 = 正在统计阿波罗计划着陆次数…
+	}
+}


### PR DESCRIPTION
* In `/JNSQ_Bodies/*.cfg`, some of the biome descriptions were hard-coded rather than via variables. This made the corresponding translations in `/JNSQ_Localization/*.cfg` unable to be loaded.
* In `/JNSQ_Bodies/Laythe.cfg`, name for the biome Polward Sea was `Polward Sea`, rather than the expected `PolwardSea`. This prevented the "Polward Sea" translation from being loaded and I couldn't properly fix it. So I wrote a patch for a temporary fix.
* Four localization variables (`#LOC_JNSQ_Biome_WelcomeBackIsland`, `#LOC_JNSQ_Biome_Whites`, `#LOC_JNSQ_Biome_Basins` and `#LOC_JNSQ_Biome_PolarIceCraters`) were not defined in the Gemany, English, Spanish and Italian localization files. I added those variables but _with the English translation only_ (i.e. untranslated). Anyone who speaks Gemany, Spanish or Italian please help with this.
* The variable names for ResearchBodies defined in `/JNSQ_Localization/*.cfg` did not match those actually used by the said mod.
* Added Chinese (zh-cn) localization.